### PR TITLE
fix: correct URL construction in license add

### DIFF
--- a/internal/resource_licenses.go
+++ b/internal/resource_licenses.go
@@ -57,7 +57,7 @@ func resourceLicensesCreate(d *schema.ResourceData, meta interface{}) error {
 		Key: licenseKey,
 	}
 
-	url := fmt.Sprintf("%s/licenses/add", client.Endpoint)
+	url := "/licenses/add"
 	if force {
 		url += "?force=true"
 	}


### PR DESCRIPTION
# Correct URL construction in license add

Just a small PR to fix adding licenses, the resourceLicensesCreate function was manually constructing the full URL by concatenating client.Endpoint with the path, which caused URL duplication as client.DoRequest also concatenates its input with the client.Endpoint resulting in duplication.

If needed/wanted I could create an issue for this, but I figured with how small of a bug this was it isn't necessary.