### PR TITLE
[Documentation] define ldap_settings nested arguments

### DIFF
--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -63,29 +63,40 @@ trraform apply
 | `required_password_length`| number   | 🚫 no    | Minimum password length for users        |
 
 ### `ldap_settings` Block
-| Name                    | Type         | Required | Description                                   |
-| ----------------------- | ------------ | -------- | --------------------------------------------- |
-| `anonymous_mode`        | bool         | 🚫 no    | Use anonymous bind                            |
-| `auto_create_users`     | bool         | 🚫 no    | Automatically create users on login           |
-| `password`              | string       | 🚫 no    | Password for bind account (use `reader_dn`)   |
-| `reader_dn`             | string       | 🚫 no    | Reader distinguished name                     |
-| `start_tls`             | bool         | 🚫 no    | Enable StartTLS for LDAP connection           |
-| `url`                   | string       | ✅ yes    | LDAP server URL, e.g., `ldap.example.com:389`|
-| `search_settings`       | list(object) | 🚫 no    | List of user search settings                  |
-| `base_dn`             | string       | 🚫 no    | Base DN for user search                         |
-| `filter`              | string       | 🚫 no    | Filter to find user entries                     |
-| `user_name_attribute` | string       | 🚫 no    | Attribute for usernames (e.g., `uid`)           |
-| `group_search_settings` | list(object) | 🚫 no    | List of group search configurations           |
-| `group_attribute`     | string       | 🚫 no    | LDAP attribute representing group membership    |
-| `group_base_dn`       | string       | 🚫 no    | Base DN for group search                        |
-| `group_filter`        | string       | 🚫 no    | Filter to locate groups                         |
-| `tls_config`            | object       | 🚫 no    | TLS configuration for secure LDAP             |
-| `tls`                 | bool         | 🚫 no    | Enable TLS                                      |
-| `tls_ca_cert`         | string       | 🚫 no    | Path to CA cert file                            |
-| `tls_cert`            | string       | 🚫 no    | Path to client cert file                        |
-| `tls_key`             | string       | 🚫 no    | Path to client key file                         |
-| `tls_skip_verify`     | bool         | 🚫 no    | Skip certificate verification                   |
+| Name                    | Type         | Required | Description                                                                               |
+| ----------------------- | ------------ | -------- | ------------------------------------------------------------------------------------------|
+| `anonymous_mode`        | bool         | 🚫 no    | Use anonymous bind                                                                        |
+| `auto_create_users`     | bool         | 🚫 no    | Automatically create users on login                                                       |
+| `password`              | string       | 🚫 no    | Password for bind account (use `reader_dn`)                                               |
+| `reader_dn`             | string       | 🚫 no    | Reader distinguished name                                                                 |
+| `start_tls`             | bool         | 🚫 no    | Enable StartTLS for LDAP connection                                                       |
+| `url`                   | string       | ✅ yes    | LDAP server URL, e.g., `ldap.example.com:389`                                            |
+| `search_settings`       | list(object) | 🚫 no    | List of user search settings ([nested block](#search_settings-nested-block))              |
+| `group_search_settings` | list(object) | 🚫 no    | List of group search configurations ([nested block](#group_search_settings-nested-block)) |
+| `tls_config`            | object       | 🚫 no    | TLS configuration for secure LDAP ([nested block](#tls_config-nested-block))              |
 
+#### `search_settings` Nested Block
+| Name                  | Type     | Required | Description                            |
+|-----------------------|----------|----------|----------------------------------------|
+| `base_dn`             | string   | 🚫 no    | Base DN for user search               |
+| `filter`              | string   | 🚫 no    | Filter to find user entries           |
+| `user_name_attribute` | string   | 🚫 no    | Attribute for usernames (e.g., `uid`) |
+
+#### `group_search_settings` Nested Block
+| Name                  | Type     | Required | Description                                  |
+|-----------------------|----------|----------|----------------------------------------------|
+| `group_attribute`     | string   | 🚫 no    | LDAP attribute representing group membership |
+| `group_base_dn`       | string   | 🚫 no    | Base DN for group search                     |
+| `group_filter`        | string   | 🚫 no    | Filter to locate groups                      |
+
+#### `tls_config` Nested Block
+| Name                  | Type     | Required | Description                   |
+|-----------------------|----------|----------|-------------------------------|
+| `tls`                 | bool     | 🚫 no    | Enable TLS                    |
+| `tls_ca_cert`         | string   | 🚫 no    | Path to CA cert file          |
+| `tls_cert`            | string   | 🚫 no    | Path to client cert file      |
+| `tls_key`             | string   | 🚫 no    | Path to client key file       |
+| `tls_skip_verify`     | bool     | 🚫 no    | Skip certificate verification |
 
 ### `oauth_settings` Block
 | Name                  | Type           | Required | Description                                                                 |


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Define `ldap_settings` nested arguments as their own block

This PR implements the following changes:
<!--
Further paragraphs come after blank lines, if needed.

 - Bullet points are okay, too
 - A hyphen or asterisk is used for the bullet, preceded by a single space.

 # Please provide enough information so that others can review your pull request:


# Explain the details for making this change. What existing problem does the pull request solve?
-->
- split `search_settings` block documentation
- split `group_search_settings` block documentation
- split `tls_config` block documentation

It is not clear that the `ldap_settings` block has nested schema.
With the current documentation it gives the impression the arguments under `search_settings`, `group_search_settings`, and `tls_config` are directly under `ldap_settings`.


