### PR TITLE
Update misspelling of Terraform in docs.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -235,3 +235,4 @@ See the [LICENSE](https://github.com/portainer/terraform-provider-portainer/blob
 - [Portainer](https://portainer.io)
 - [OpenTofu](https://opentofu.org/)
 - [Docker](https://www.docker.com/)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -235,4 +235,3 @@ See the [LICENSE](https://github.com/portainer/terraform-provider-portainer/blob
 - [Portainer](https://portainer.io)
 - [OpenTofu](https://opentofu.org/)
 - [Docker](https://www.docker.com/)
-

--- a/docs/resources/endpoint_association.md
+++ b/docs/resources/endpoint_association.md
@@ -14,7 +14,7 @@ resource "portainer_endpoint_association" "example" {
 ## Lifecycle & Behavior
 For de-association of the Edge environment run:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Arguments Reference

--- a/docs/resources/endpoint_service_update.md
+++ b/docs/resources/endpoint_service_update.md
@@ -18,7 +18,7 @@ resource "portainer_endpoint_service_update" "force_update_some_service" {
 - If pull_image is set to true, Portainer will pull the latest image before updating.
 Update service run by:
 ```hcl
-trraform apply
+terraform apply
 ```
 > Note: This resource does not persist – it's meant for imperative actions like force-pulling & restarting a service.
 

--- a/docs/resources/endpoint_settings.md
+++ b/docs/resources/endpoint_settings.md
@@ -33,7 +33,7 @@ resource "portainer_endpoint_settings" "example" {
 ## Lifecycle & Behavior
 Settings of Endpoints in Portainer are modify if any of the arguments change by run:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Arguments Reference

--- a/docs/resources/endpoint_snapshot.md
+++ b/docs/resources/endpoint_snapshot.md
@@ -18,7 +18,7 @@ resource "portainer_endpoints_snapshot" "specific" {
 ## Lifecycle & Behavior
 Snapshot is executed during:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Arguments Reference

--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -30,7 +30,7 @@ resource "portainer_settings" "example" {
 ## Lifecycle & Behavior
 Settings of Portainer are modify if any of the arguments change by run:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Arguments Reference

--- a/docs/resources/ssl.md
+++ b/docs/resources/ssl.md
@@ -19,7 +19,7 @@ resource "portainer_ssl" "cert_update" {
 ## Lifecycle & Behavior
 SSL of Portainer are modify if any of the arguments/files change by run:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Example make SSL ceert

--- a/docs/resources/stack_associate.md
+++ b/docs/resources/stack_associate.md
@@ -20,7 +20,7 @@ resource "portainer_stack_associate" "example" {
 ## Lifecycle & Behavior
 For de-association of the Stack in docker swarm run:
 ```hcl
-trraform apply
+terraform apply
 ```
 
 ## Arguments Reference


### PR DESCRIPTION
The simplest of documentation updates to correct the misspelling of "Terraform".

Resource docs affected:
- docs/resources/endpoint_association.md
- docs/resources/endpoint_service_update.md
- docs/resources/endpoint_settings.md
- docs/resources/endpoint_snapshot.md
- docs/resources/settings.md
- docs/resources/ssl.md
- docs/resources/stack_associate.md