### PR TITLE
Fix: edge configurations assigned wrong ID when non-Terraform configs exist

### DIFF
--- a/internal/resource_edge_configurations.go
+++ b/internal/resource_edge_configurations.go
@@ -115,32 +115,15 @@ func resourcePortainerEdgeConfigurationsCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("failed to create edge configuration: %s", string(respBody))
 	}
 
-	filterBytes, _ := json.Marshal(payload)
-	getReq, err := http.NewRequest("GET", fmt.Sprintf("%s/edge_configurations", client.Endpoint), bytes.NewReader(filterBytes))
-	if err != nil {
-		return fmt.Errorf("failed to build GET request for lookup: %w", err)
+	var created EdgeConfiguration
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return fmt.Errorf("failed to decode create response: %w", err)
 	}
-	getReq.Header.Set("Content-Type", "application/json")
-	if client.APIKey != "" {
-		getReq.Header.Set("X-API-Key", client.APIKey)
-	} else if client.JWTToken != "" {
-		getReq.Header.Set("Authorization", "Bearer "+client.JWTToken)
-	}
-	getResp, err := client.HTTPClient.Do(getReq)
-	if err != nil {
-		return fmt.Errorf("failed to send GET lookup request: %w", err)
-	}
-	defer getResp.Body.Close()
-
-	var configs []EdgeConfiguration
-	if err := json.NewDecoder(getResp.Body).Decode(&configs); err != nil {
-		return fmt.Errorf("failed to decode GET response: %w", err)
-	}
-	if len(configs) == 0 {
-		return fmt.Errorf("no edge configuration found after creation")
+	if created.ID == 0 {
+		return fmt.Errorf("edge configuration created but no ID returned")
 	}
 
-	d.SetId(strconv.Itoa(configs[0].ID))
+	d.SetId(strconv.Itoa(created.ID))
 	return nil
 }
 

--- a/internal/resource_edge_configurations.go
+++ b/internal/resource_edge_configurations.go
@@ -115,12 +115,48 @@ func resourcePortainerEdgeConfigurationsCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("failed to create edge configuration: %s", string(respBody))
 	}
 
-	var created EdgeConfiguration
-	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
-		return fmt.Errorf("failed to decode create response: %w", err)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read create response: %w", err)
 	}
+
+	var created EdgeConfiguration
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &created); err != nil {
+			return fmt.Errorf("failed to decode create response: %w", err)
+		}
+	}
+
 	if created.ID == 0 {
-		return fmt.Errorf("edge configuration created but no ID returned")
+		// API returned empty body — find the created config by name
+		name := d.Get("name").(string)
+		listReq, err := http.NewRequest("GET", fmt.Sprintf("%s/edge_configurations", client.Endpoint), nil)
+		if err != nil {
+			return fmt.Errorf("failed to build list request: %w", err)
+		}
+		if client.APIKey != "" {
+			listReq.Header.Set("X-API-Key", client.APIKey)
+		} else if client.JWTToken != "" {
+			listReq.Header.Set("Authorization", "Bearer "+client.JWTToken)
+		}
+		listResp, err := client.HTTPClient.Do(listReq)
+		if err != nil {
+			return fmt.Errorf("failed to list edge configurations: %w", err)
+		}
+		defer listResp.Body.Close()
+		var configs []EdgeConfiguration
+		if err := json.NewDecoder(listResp.Body).Decode(&configs); err != nil {
+			return fmt.Errorf("failed to decode edge configurations list: %w", err)
+		}
+		for _, c := range configs {
+			if c.Name == name {
+				created = c
+				break
+			}
+		}
+		if created.ID == 0 {
+			return fmt.Errorf("edge configuration created but could not determine its ID")
+		}
 	}
 
 	d.SetId(strconv.Itoa(created.ID))


### PR DESCRIPTION
Fix: edge configurations assigned wrong ID when non-Terraform configs exist

This PR fixes two related bugs in portainer_edge_configurations create/ID resolution.

Changes
Bug 1: Wrong resource ID assigned on create

The previous implementation resolved the newly created edge configuration ID by sending a GET /edge_configurations request and taking configs[0].ID, the first result in the list. If any edge configurations existed in Portainer that were not managed by Terraform (e.g. manually created), the wrong ID would be stored in state. This caused subsequent reads and deletes to target the wrong resource.

Bug 2: Create fails when API returns empty response body

The Portainer API returns an empty body on a successful POST /edge_configurations. The previous code attempted to decode the POST response directly, which produced an EOF error and failed the apply.

Fix
Read the POST response body first; if non-empty, decode it directly to get the ID
If the body is empty (as the API currently behaves), fall back to GET /edge_configurations and match by name rather than taking the first result
This ensures the correct ID is always stored in state regardless of what other edge configurations exist in Portainer

Testing
Verified locally with a Portainer instance that had pre-existing manually-created edge configurations. Terraform correctly identified and tracked the newly created configuration by name, and terraform destroy deleted only the Terraform-managed resource.