### PR TITLE
Fix invalid form data in PUT request when updating edge configs

### DIFF
--- a/internal/resource_edge_configurations.go
+++ b/internal/resource_edge_configurations.go
@@ -309,15 +309,22 @@ func resourcePortainerEdgeConfigurationsUpdate(d *schema.ResourceData, meta inte
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	edgeGroupIDs := convertToIntSlice(d.Get("edge_group_ids").([]interface{}))
-	edgeGroupIDsBytes, err := json.Marshal(edgeGroupIDs)
-	if err != nil {
-		return fmt.Errorf("failed to marshal edgeGroupIDs: %w", err)
+	// Portainer API docs are incorrect. API expects form data as follows,
+	// note lower case naming as well:
+	// edgeConfiguration: {"edgeGroupIDs":[...],"type":"..."}
+	// file:              (binary file)
+	payload := map[string]interface{}{
+		"type":         d.Get("type").(string),
+		"edgeGroupIDs": convertToIntSlice(d.Get("edge_group_ids").([]interface{})),
 	}
-	_ = writer.WriteField("EdgeGroupIDs", string(edgeGroupIDsBytes))
-	_ = writer.WriteField("Type", d.Get("type").(string))
 
-	part, err := writer.CreateFormFile("File", filepath.Base(filePath))
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal edgeConfiguration payload: %w", err)
+	}
+	_ = writer.WriteField("edgeConfiguration", string(payloadBytes))
+
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
 	if err != nil {
 		return fmt.Errorf("failed to create form file: %w", err)
 	}


### PR DESCRIPTION
<!--
IMPORTANT: Please have a look at the contribution guidelines first.
-->
# Fix "Missing form data value" error when updating `portainer_edge_configurations`

This PR implements the following changes:

Updates form data in `edge_configurations` PUT request. type and groupIDs should be inside `edgeConfiguration` field and key names should not start with a capital.

 # Please provide enough information so that others can review your pull request:

The Portainer API docs are incorrect in this case. I've tested this locally against the latest LTS (2.39.1) after looking at the data the frontend submits when doing an update:
<img width="533" height="152" alt="image" src="https://github.com/user-attachments/assets/29a671c0-ef6a-49aa-a5bb-3ff7a46f0f74" />
