### PR TITLE
Fix edge stack import by populating full state and relaxing ForceNew flags

### DIFF
--- a/docs/resources/edge_stack.md
+++ b/docs/resources/edge_stack.md
@@ -185,3 +185,12 @@ Edge stacks can be imported using their numeric ID:
 ```shell
 terraform import portainer_edge_stack.example 42
 ```
+
+After import, run `terraform show` to verify the imported state, then `terraform plan` to confirm no changes are pending. For git-backed stacks, the plan should show **no changes** when your `.tf` config matches the live stack.
+
+### Which fields update in place vs. force recreation
+
+Portainer's `PUT /edge_stacks/{id}/git` endpoint only honors a subset of the git config:
+
+- **Updated in place:** `repository_reference_name` (and edge group / deployment-type changes via the same endpoint). The stack ID, edge agent bindings, and webhook are preserved.
+- **Forces recreation (`ForceNew`):** `repository_url`, `file_path_in_repository`, `repository_username`, `repository_password`, `relative_path`, and `stack_file_path`. The Portainer git-update endpoint does not expose source URL or in-repo file-path mutation; changing the source means a different stack from Portainer's perspective.

--- a/internal/resource_edge_stack.go
+++ b/internal/resource_edge_stack.go
@@ -95,9 +95,8 @@ func resourceEdgeStack() *schema.Resource {
 			"repository_reference_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     "refs/heads/main",
-				Description: "Git reference (branch or tag) to check out from the repository. Changing this value forces resource recreation.",
+				Description: "Git reference (branch or tag) to check out from the repository.",
 			},
 			"file_path_in_repository": {
 				Type:        schema.TypeString,
@@ -470,6 +469,11 @@ func resourceEdgeStackUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Repository-based update via /git
+	// Portainer's PUT /edge_stacks/{id}/git endpoint silently ignores any
+	// `repositoryURL` / `filePathInRepository` fields in the payload — only
+	// `refName` and the authentication block are honored. Changing the source
+	// URL or in-repo file path requires recreating the stack (enforced via
+	// ForceNew on the matching schema attributes).
 	if repoURL, ok := d.GetOk("repository_url"); ok && repoURL.(string) != "" {
 		payload := map[string]interface{}{
 			"deploymentType": deploymentType,
@@ -617,22 +621,36 @@ func resourceEdgeStackRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var stack struct {
-		Name    string `json:"Name"`
-		EnvVars []struct {
+		Name                              string `json:"Name"`
+		EdgeGroups                        []int  `json:"EdgeGroups"`
+		DeploymentType                    int    `json:"DeploymentType"`
+		UseManifestNamespaces             bool   `json:"UseManifestNamespaces"`
+		Registries                        []int  `json:"Registries"`
+		PrePullImage                      bool   `json:"PrePullImage"`
+		RePullImage                       bool   `json:"RePullImage"`
+		RetryDeploy                       bool   `json:"RetryDeploy"`
+		SupportRelativePath               bool   `json:"SupportRelativePath"`
+		FilesystemPath                    string `json:"FilesystemPath"`
+		AlwaysCloneGitRepoForRelativePath bool   `json:"AlwaysCloneGitRepoForRelativePath"`
+		EnvVars                           []struct {
 			Name  string `json:"name"`
 			Value string `json:"value"`
-		} `json:"envVars"`
+		} `json:"EnvVars"`
 		GitConfig *struct {
-			Authentication struct {
-				GitCredentialID int `json:"GitCredentialID"`
+			URL            string `json:"URL"`
+			ReferenceName  string `json:"ReferenceName"`
+			ConfigFilePath string `json:"ConfigFilePath"`
+			Authentication *struct {
+				Username        string `json:"Username"`
+				GitCredentialID int    `json:"GitCredentialID"`
 			} `json:"Authentication"`
 		} `json:"GitConfig"`
 		AutoUpdate *struct {
 			Interval       string `json:"Interval"`
 			Webhook        string `json:"Webhook"`
 			ForcePullImage bool   `json:"ForcePullImage"`
+			ForceUpdate    bool   `json:"ForceUpdate"`
 		} `json:"AutoUpdate,omitempty"`
-		AlwaysCloneGitRepoForRelativePath bool `json:"AlwaysCloneGitRepoForRelativePath"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
@@ -640,22 +658,74 @@ func resourceEdgeStackRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", stack.Name)
-	envMap := make(map[string]string)
+	d.Set("deployment_type", stack.DeploymentType)
+	d.Set("dryrun", false) // write-only creation flag, API never returns it
+	d.Set("edge_groups", stack.EdgeGroups)
+	d.Set("registries", stack.Registries)
+	d.Set("use_manifest_namespaces", stack.UseManifestNamespaces)
+	d.Set("pre_pull_image", stack.PrePullImage)
+	d.Set("retry_deploy", stack.RetryDeploy)
+	d.Set("always_clone", stack.AlwaysCloneGitRepoForRelativePath)
+
+	envMap := make(map[string]string, len(stack.EnvVars))
 	for _, env := range stack.EnvVars {
 		envMap[env.Name] = env.Value
 	}
+
 	if len(envMap) > 0 {
 		d.Set("environment", envMap)
 	}
 
+	if stack.SupportRelativePath {
+		d.Set("relative_path", stack.FilesystemPath)
+	}
+
 	if stack.GitConfig != nil {
-		d.Set("repository_git_credential_id", stack.GitConfig.Authentication.GitCredentialID)
+		d.Set("repository_url", stack.GitConfig.URL)
+		d.Set("repository_reference_name", stack.GitConfig.ReferenceName)
+		d.Set("file_path_in_repository", stack.GitConfig.ConfigFilePath)
+		if stack.GitConfig.Authentication != nil {
+			d.Set("git_repository_authentication", true)
+			d.Set("repository_username", stack.GitConfig.Authentication.Username)
+			d.Set("repository_git_credential_id", stack.GitConfig.Authentication.GitCredentialID)
+		} else {
+			d.Set("git_repository_authentication", false)
+		}
 	}
+
+	// pull_image is sent to two different places in Create/Update payloads:
+	// top-level rePullImage (always) and autoUpdate.forcePullImage (only when
+	// GitOps is configured). The API persists both. Use top-level RePullImage
+	// as the source of truth, and let AutoUpdate.ForcePullImage override when
+	// AutoUpdate exists since that's the value the user-configured GitOps block
+	// carries.
+	d.Set("pull_image", stack.RePullImage)
+
 	if stack.AutoUpdate != nil {
-		d.Set("pull_image", stack.AutoUpdate.ForcePullImage)
 		d.Set("update_interval", stack.AutoUpdate.Interval)
+		d.Set("pull_image", stack.AutoUpdate.ForcePullImage)
+		d.Set("force_update", stack.AutoUpdate.ForceUpdate)
+		if stack.AutoUpdate.Webhook != "" {
+			d.Set("stack_webhook", true)
+			d.Set("webhook_id", stack.AutoUpdate.Webhook)
+			baseURL := strings.TrimSuffix(client.Endpoint, "/api")
+			d.Set("webhook_url", fmt.Sprintf("%s/api/edge_stacks/webhooks/%s", baseURL, stack.AutoUpdate.Webhook))
+		} else {
+			// AutoUpdate exists but webhook was cleared — drop any stale
+			// computed outputs so state reflects reality.
+			d.Set("stack_webhook", false)
+			d.Set("webhook_id", "")
+			d.Set("webhook_url", "")
+		}
+	} else {
+		// No GitOps configured — clear all AutoUpdate-derived fields,
+		// including webhook outputs that may have been set previously.
+		d.Set("force_update", false)
+		d.Set("stack_webhook", false)
+		d.Set("update_interval", "")
+		d.Set("webhook_id", "")
+		d.Set("webhook_url", "")
 	}
-	d.Set("always_clone", stack.AlwaysCloneGitRepoForRelativePath)
 
 	return nil
 }


### PR DESCRIPTION
## Description

### 🚨 Problem
Running `terraform import` on a git-backed edge stack followed immediately by `terraform plan` proposed a **destroy + recreate (`-/+`)** of the live stack.

* **Root Cause:** `resourceEdgeStackRead` only wrote 4 of ~20 API-returned fields into the Terraform state. 
* **The Culprit:** The three `ForceNew` fields (`repository_url`, `repository_reference_name`, `file_path_in_repository`) were left `null` in the state after an import. Terraform interpreted this as a configuration change and forced a full resource replacement.

---

## 🛠️ Changes

### 1. Read Expansion (Main Fix)
Expanded the API response struct and `d.Set()` coverage to fully populate **every** field returned by `GET /edge_stacks/{id}`. This ensures the state accurately reflects reality post-import:
* Deployment type & Edge groups
* Registries
* Git configuration (URL, ref, file path, auth)
* AutoUpdate block (interval, webhook, force flags)
* Relative path & all boolean flags

### 2. AutoUpdate Nil Guard
Added explicit zero-value writes when `AutoUpdate` is `nil`. Previously, these fields were left unset in the state, causing irritating `+ false` noise on every subsequent `terraform plan`.

### 3. `dryrun` Fix
`dryrun` is a write-only creation flag that the API never returns. It is now explicitly set to `false` during the Read phase (with an explanatory comment) to prevent `+ false` drift.

### 4. ForceNew: Unlocked for `repository_reference_name` Only
The `PUT /edge_stacks/{id}/git` API endpoint verifiably honors `refName` changes in-place. 
* *Testing confirmed:* Passing an invalid ref returns a clear API error; passing a valid ref change applies it in-place while preserving the stack ID and agent bindings.

Other Git configuration fields **retain `ForceNew`** because the API currently drops them silently.

| Field | Behavior After This PR | Reason / API Behavior |
| :--- | :--- | :--- |
| `repository_reference_name` | **In-place Update** 🔓 | Supported and honored by `PUT /edge_stacks/{id}/git` |
| `repository_url` | **ForceNew (`-/+`)** 🔒 | API silently drops changes; unsafe for in-place |
| `file_path_in_repository` | **ForceNew (`-/+`)** 🔒 | API silently drops changes; unsafe for in-place |
| `repository_username` | **ForceNew (`-/+`)** 🔒 | API silently drops changes; unsafe for in-place |
| `repository_password` | **ForceNew (`-/+`)** 🔒 | API silently drops changes; unsafe for in-place |
| `relative_path` | **ForceNew (`-/+`)** 🔒 | API silently drops changes; unsafe for in-place |

---

## ✅ Verified & Tested
* **Environment:** Portainer EE v2.43.0 STS
* **Import Workflow:** `terraform import` ➡️ `terraform plan` now returns **No changes** on matching configurations (previously forced a `-/+` replacement).
* **Ref Changes:** Updating `repository_reference_name` plans and applies perfectly in-place; the stack ID is successfully preserved.
* **URL Changes:** Updating `repository_url` correctly triggers a `-/+` replacement as expected.