### PR TITLE
Fix edge stack Read to support non-destructive brownfield import

### DIFF
--- a/docs/resources/edge_stack.md
+++ b/docs/resources/edge_stack.md
@@ -185,3 +185,12 @@ Edge stacks can be imported using their numeric ID:
 ```shell
 terraform import portainer_edge_stack.example 42
 ```
+
+After import, run `terraform show` to verify the imported state, then `terraform plan` to confirm no changes are pending. For git-backed stacks, the plan should show **no changes** when your `.tf` config matches the live stack.
+
+### Which fields update in place vs. force recreation
+
+Portainer's `PUT /edge_stacks/{id}/git` endpoint only honors a subset of the git config:
+
+- **Updated in place:** `repository_reference_name` (and edge group / deployment-type changes via the same endpoint). The stack ID, edge agent bindings, and webhook are preserved.
+- **Forces recreation (`ForceNew`):** `repository_url`, `file_path_in_repository`, `repository_username`, `repository_password`, `relative_path`, and `stack_file_path`. The Portainer git-update endpoint does not expose source URL or in-repo file-path mutation; changing the source means a different stack from Portainer's perspective.

--- a/internal/resource_edge_stack.go
+++ b/internal/resource_edge_stack.go
@@ -95,9 +95,8 @@ func resourceEdgeStack() *schema.Resource {
 			"repository_reference_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     "refs/heads/main",
-				Description: "Git reference (branch or tag) to check out from the repository. Changing this value forces resource recreation.",
+				Description: "Git reference (branch or tag) to check out from the repository.",
 			},
 			"file_path_in_repository": {
 				Type:        schema.TypeString,
@@ -470,6 +469,11 @@ func resourceEdgeStackUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Repository-based update via /git
+	// Portainer's PUT /edge_stacks/{id}/git endpoint silently ignores any
+	// `repositoryURL` / `filePathInRepository` fields in the payload — only
+	// `refName` and the authentication block are honored. Changing the source
+	// URL or in-repo file path requires recreating the stack (enforced via
+	// ForceNew on the matching schema attributes).
 	if repoURL, ok := d.GetOk("repository_url"); ok && repoURL.(string) != "" {
 		payload := map[string]interface{}{
 			"deploymentType": deploymentType,
@@ -617,22 +621,36 @@ func resourceEdgeStackRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var stack struct {
-		Name    string `json:"Name"`
-		EnvVars []struct {
+		Name                              string `json:"Name"`
+		EdgeGroups                        []int  `json:"EdgeGroups"`
+		DeploymentType                    int    `json:"DeploymentType"`
+		UseManifestNamespaces             bool   `json:"UseManifestNamespaces"`
+		Registries                        []int  `json:"Registries"`
+		PrePullImage                      bool   `json:"PrePullImage"`
+		RePullImage                       bool   `json:"RePullImage"`
+		RetryDeploy                       bool   `json:"RetryDeploy"`
+		SupportRelativePath               bool   `json:"SupportRelativePath"`
+		FilesystemPath                    string `json:"FilesystemPath"`
+		AlwaysCloneGitRepoForRelativePath bool   `json:"AlwaysCloneGitRepoForRelativePath"`
+		EnvVars                           []struct {
 			Name  string `json:"name"`
 			Value string `json:"value"`
-		} `json:"envVars"`
+		} `json:"EnvVars"`
 		GitConfig *struct {
-			Authentication struct {
-				GitCredentialID int `json:"GitCredentialID"`
+			URL            string `json:"URL"`
+			ReferenceName  string `json:"ReferenceName"`
+			ConfigFilePath string `json:"ConfigFilePath"`
+			Authentication *struct {
+				Username        string `json:"Username"`
+				GitCredentialID int    `json:"GitCredentialID"`
 			} `json:"Authentication"`
 		} `json:"GitConfig"`
 		AutoUpdate *struct {
 			Interval       string `json:"Interval"`
 			Webhook        string `json:"Webhook"`
 			ForcePullImage bool   `json:"ForcePullImage"`
+			ForceUpdate    bool   `json:"ForceUpdate"`
 		} `json:"AutoUpdate,omitempty"`
-		AlwaysCloneGitRepoForRelativePath bool `json:"AlwaysCloneGitRepoForRelativePath"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
@@ -640,22 +658,74 @@ func resourceEdgeStackRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", stack.Name)
-	envMap := make(map[string]string)
+	d.Set("deployment_type", stack.DeploymentType)
+	d.Set("dryrun", false) // write-only creation flag, API never returns it
+	d.Set("edge_groups", stack.EdgeGroups)
+	d.Set("registries", stack.Registries)
+	d.Set("use_manifest_namespaces", stack.UseManifestNamespaces)
+	d.Set("pre_pull_image", stack.PrePullImage)
+	d.Set("retry_deploy", stack.RetryDeploy)
+	d.Set("always_clone", stack.AlwaysCloneGitRepoForRelativePath)
+
+	envMap := make(map[string]string, len(stack.EnvVars))
 	for _, env := range stack.EnvVars {
 		envMap[env.Name] = env.Value
 	}
+
 	if len(envMap) > 0 {
 		d.Set("environment", envMap)
 	}
 
+	if stack.SupportRelativePath {
+		d.Set("relative_path", stack.FilesystemPath)
+	}
+
 	if stack.GitConfig != nil {
-		d.Set("repository_git_credential_id", stack.GitConfig.Authentication.GitCredentialID)
+		d.Set("repository_url", stack.GitConfig.URL)
+		d.Set("repository_reference_name", stack.GitConfig.ReferenceName)
+		d.Set("file_path_in_repository", stack.GitConfig.ConfigFilePath)
+		if stack.GitConfig.Authentication != nil {
+			d.Set("git_repository_authentication", true)
+			d.Set("repository_username", stack.GitConfig.Authentication.Username)
+			d.Set("repository_git_credential_id", stack.GitConfig.Authentication.GitCredentialID)
+		} else {
+			d.Set("git_repository_authentication", false)
+		}
 	}
+
+	// pull_image is sent to two different places in Create/Update payloads:
+	// top-level rePullImage (always) and autoUpdate.forcePullImage (only when
+	// GitOps is configured). The API persists both. Use top-level RePullImage
+	// as the source of truth, and let AutoUpdate.ForcePullImage override when
+	// AutoUpdate exists since that's the value the user-configured GitOps block
+	// carries.
+	d.Set("pull_image", stack.RePullImage)
+
 	if stack.AutoUpdate != nil {
-		d.Set("pull_image", stack.AutoUpdate.ForcePullImage)
 		d.Set("update_interval", stack.AutoUpdate.Interval)
+		d.Set("pull_image", stack.AutoUpdate.ForcePullImage)
+		d.Set("force_update", stack.AutoUpdate.ForceUpdate)
+		if stack.AutoUpdate.Webhook != "" {
+			d.Set("stack_webhook", true)
+			d.Set("webhook_id", stack.AutoUpdate.Webhook)
+			baseURL := strings.TrimSuffix(client.Endpoint, "/api")
+			d.Set("webhook_url", fmt.Sprintf("%s/api/edge_stacks/webhooks/%s", baseURL, stack.AutoUpdate.Webhook))
+		} else {
+			// AutoUpdate exists but webhook was cleared — drop any stale
+			// computed outputs so state reflects reality.
+			d.Set("stack_webhook", false)
+			d.Set("webhook_id", "")
+			d.Set("webhook_url", "")
+		}
+	} else {
+		// No GitOps configured — clear all AutoUpdate-derived fields,
+		// including webhook outputs that may have been set previously.
+		d.Set("force_update", false)
+		d.Set("stack_webhook", false)
+		d.Set("update_interval", "")
+		d.Set("webhook_id", "")
+		d.Set("webhook_url", "")
 	}
-	d.Set("always_clone", stack.AlwaysCloneGitRepoForRelativePath)
 
 	return nil
 }


### PR DESCRIPTION
# fix(edge_stack): make brownfield import non-destructive

## Summary

`terraform import` of an existing edge stack used to leave state nearly empty, so the very next `terraform plan` proposed **destroying and recreating** the stack — even when the config matched reality exactly. This made brownfield adoption of the provider unusable for git-backed edge stacks.

This PR fixes `resourceEdgeStackRead` to populate full state on import, and corrects one over-broad `ForceNew` flag so legitimate ref changes update in place instead of forcing replacement.

## The problem

After `terraform import portainer_edge_stack.x 1`:

- `terraform show` wrote only **4 fields** to state — no git config, no edge groups, no deployment metadata.
- `terraform plan` then showed `-/+ resource ... must be replaced` (1 to add, 1 to destroy), because the config looked like it was *introducing* attributes for the first time — and three of them (`repository_url`, `repository_reference_name`, `file_path_in_repository`) were `ForceNew`.
- Applying that plan would `DELETE /edge_stacks/1`, recreate with a new ID, force every edge agent to rebind, and lose deployment history + the webhook UUID.

## Root cause

1. **`Read` didn't populate state.** `resourceEdgeStackRead` decoded only 6 of the ~20 fields `GET /edge_stacks/{id}` returns. Everything else stayed null, so plan treated the config as new attributes — and the `ForceNew` ones forced replacement.
2. **`ForceNew` over-applied.** `repository_reference_name` was `ForceNew` even though Portainer's `PUT /edge_stacks/{id}/git` endpoint updates the ref in place via `refName`.

## What changed

`internal/resource_edge_stack.go`:

- **Expanded the `GET /edge_stacks/{id}` response struct** and added `d.Set(...)` for all returned fields: `name`, `deployment_type`, `edge_groups`, `registries`, `use_manifest_namespaces`, `pre_pull_image`, `retry_deploy`, `always_clone`, `environment`, `relative_path`, the git config block, and the `AutoUpdate`-derived fields.
- **Made `GitConfig.Authentication` a pointer** so Read can distinguish "no auth configured" (`nil`) from a zero-valued credential ID, and set `git_repository_authentication` accordingly (the old value-struct could never represent the "no auth" case and wrote a phantom `repository_git_credential_id = 0`).
- **Added `AutoUpdate.ForceUpdate`** to the decoded struct so `force_update` is populated instead of showing `+ false` on every plan.
- **Set explicit defaults in Read** for `dryrun` and the `AutoUpdate`-derived fields (`pull_image`, `force_update`, `stack_webhook`, `update_interval`) so a stack without GitOps doesn't produce spurious diffs.
- **Dropped `ForceNew` from `repository_reference_name` only** — it's the one git field `PUT /git` mutates in place. `repository_url`, `file_path_in_repository`, `repository_username`, `repository_password`, `relative_path`, and `stack_file_path` keep `ForceNew` (the git endpoint silently ignores those in the payload — see the comment added to `resourceEdgeStackUpdate`).

`docs/resources/edge_stack.md`:

- Documented the post-import verification flow and which fields update in place vs. force recreation.

## Behavior contrast

| Scenario | Before | After |
|---|---|---|
| Fields populated by Read after import | 4 | 19 |
| `terraform plan` on matching config | `-/+ replace` (1 add, 1 destroy) | `No changes` |
| Change `repository_reference_name` | `-/+ replace` (false positive) | `~ update in-place`, 0 destroy |
| Change `repository_url` / `file_path_in_repository` | `-/+ replace` | `-/+ replace` (correct — API can't repoint source) |
| Stack ID / agent bindings preserved on ref change | No | Yes |
| `dryrun`/`force_update`/`pull_image`/`stack_webhook` plan noise | `+ false` every plan | Stable, no diff |

## How it was verified

- `go build ./...` ✅, `go vet ./internal/` ✅
- Unit tests: `go test ./internal -run EdgeStack` ✅ (incl. `TestEdgeStackRead_HappyPath`)
- **Live, against a real Portainer instance:**
  - Imported an existing production edge stack (ID 1) → `terraform show` now writes 19 populated fields → `terraform plan` reports **`No changes. Your infrastructure matches the configuration.`**
  - Changed `repository_reference_name` → plan shows `~ update in-place`, **`Plan: 0 to add, 1 to change, 0 to destroy`** (stack ID preserved).
- CI `pr-e2e-test` exercises the `edge_repository` full create→update→delete cycle, covering the changed Read + `ForceNew` paths.

## Known follow-ups (out of scope here)

- `repository_url` / `file_path_in_repository` remain `ForceNew` — Portainer's EE `PUT /git` endpoint does not expose source-URL or in-repo file-path mutation.
- `repository_username`, `repository_password`, `relative_path` remain `ForceNew` pending a live test against a stack with auth / relative paths configured.
- `stack_file_path` remains `ForceNew` — Update has no multipart re-upload branch yet.

<!-- Optional: link the tracking issue, e.g. "Fixes #123" -->
