### PR TITLE
Fix/kubernetes read import all resources

### DIFF
--- a/docs/resources/kubernetes_application.md
+++ b/docs/resources/kubernetes_application.md
@@ -73,3 +73,11 @@ resource "portainer_portainer_kubernetes_application" "example" {
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:application:name    |
+
+## Import
+
+Kubernetes application resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_application.example 1:default:my-app
+```

--- a/docs/resources/kubernetes_application.md
+++ b/docs/resources/kubernetes_application.md
@@ -81,3 +81,5 @@ Kubernetes application resources can be imported using the composite ID `endpoin
 ```shell
 terraform import portainer_kubernetes_application.example 1:default:my-app
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_clusterrole.md
+++ b/docs/resources/kubernetes_clusterrole.md
@@ -51,3 +51,5 @@ Kubernetes ClusterRole resources can be imported using the composite ID `endpoin
 ```shell
 terraform import portainer_kubernetes_clusterrole.example 1:my-clusterrole
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_clusterrole.md
+++ b/docs/resources/kubernetes_clusterrole.md
@@ -43,3 +43,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:clusterrole:name    |
+
+## Import
+
+Kubernetes ClusterRole resources can be imported using the composite ID `endpointID:name`:
+
+```shell
+terraform import portainer_kubernetes_clusterrole.example 1:my-clusterrole
+```

--- a/docs/resources/kubernetes_clusterrolebinding.md
+++ b/docs/resources/kubernetes_clusterrolebinding.md
@@ -43,3 +43,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:clusterrolebinding:name    |
+
+## Import
+
+Kubernetes ClusterRoleBinding resources can be imported using the composite ID `endpointID:name`:
+
+```shell
+terraform import portainer_kubernetes_clusterrolebinding.example 1:my-clusterrolebinding
+```

--- a/docs/resources/kubernetes_clusterrolebinding.md
+++ b/docs/resources/kubernetes_clusterrolebinding.md
@@ -51,3 +51,5 @@ Kubernetes ClusterRoleBinding resources can be imported using the composite ID `
 ```shell
 terraform import portainer_kubernetes_clusterrolebinding.example 1:my-clusterrolebinding
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_configmaps.md
+++ b/docs/resources/kubernetes_configmaps.md
@@ -53,3 +53,5 @@ Kubernetes ConfigMap resources can be imported using the composite ID `endpointI
 ```shell
 terraform import portainer_kubernetes_configmaps.example 1:default:my-configmap
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_configmaps.md
+++ b/docs/resources/kubernetes_configmaps.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:configmaps:name    |
+
+## Import
+
+Kubernetes ConfigMap resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_configmaps.example 1:default:my-configmap
+```

--- a/docs/resources/kubernetes_cronjob.md
+++ b/docs/resources/kubernetes_cronjob.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:cronjob:name    |
+
+## Import
+
+Kubernetes CronJob resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_cronjob.example 1:default:my-cronjob
+```

--- a/docs/resources/kubernetes_cronjob.md
+++ b/docs/resources/kubernetes_cronjob.md
@@ -53,3 +53,5 @@ Kubernetes CronJob resources can be imported using the composite ID `endpointID:
 ```shell
 terraform import portainer_kubernetes_cronjob.example 1:default:my-cronjob
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_helm.md
+++ b/docs/resources/kubernetes_helm.md
@@ -66,3 +66,11 @@ resource "portainer_kubernetes_helm" "example" {
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | Unique identifier for the Helm release    |
+
+## Import
+
+Kubernetes Helm releases can be imported using the composite ID `environmentID:namespace:releaseName`:
+
+```shell
+terraform import portainer_kubernetes_helm.example 1:default:my-release
+```

--- a/docs/resources/kubernetes_helm.md
+++ b/docs/resources/kubernetes_helm.md
@@ -74,3 +74,5 @@ Kubernetes Helm releases can be imported using the composite ID `environmentID:n
 ```shell
 terraform import portainer_kubernetes_helm.example 1:default:my-release
 ```
+
+After import, set `chart`, `repo`, and `values` in config to match the live release — Read only confirms the release exists and restores identity fields. The chart/repo fields are `ForceNew`, so leaving them blank after import will trigger a destroy+recreate on the next apply, not a benign diff.

--- a/docs/resources/kubernetes_ingresses.md
+++ b/docs/resources/kubernetes_ingresses.md
@@ -96,3 +96,11 @@ resource "portainer_kubernetes_ingress" "example" {
 | Name | Description                                                      |
 | ---- | ---------------------------------------------------------------- |
 | `id` | ID of the ingress in the format `environment_id:namespace:name`. |
+
+## Import
+
+Kubernetes Ingress resources can be imported using the composite ID `environmentID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_ingresses.example 1:default:my-ingress
+```

--- a/docs/resources/kubernetes_ingresses.md
+++ b/docs/resources/kubernetes_ingresses.md
@@ -104,3 +104,5 @@ Kubernetes Ingress resources can be imported using the composite ID `environment
 ```shell
 terraform import portainer_kubernetes_ingresses.example 1:default:my-ingress
 ```
+
+After import, set `hosts`, `paths`, `tls`, `annotations`, `labels`, and `class_name` in config to match the live Ingress — Read only confirms it exists and restores identity fields, it does not reconstruct the routing spec.

--- a/docs/resources/kubernetes_job.md
+++ b/docs/resources/kubernetes_job.md
@@ -46,3 +46,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:job:name    |
+
+## Import
+
+Kubernetes Job resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_job.example 1:default:my-job
+```

--- a/docs/resources/kubernetes_job.md
+++ b/docs/resources/kubernetes_job.md
@@ -54,3 +54,5 @@ Kubernetes Job resources can be imported using the composite ID `endpointID:name
 ```shell
 terraform import portainer_kubernetes_job.example 1:default:my-job
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_namespace.md
+++ b/docs/resources/kubernetes_namespace.md
@@ -66,3 +66,5 @@ Kubernetes namespaces can be imported using the composite ID `environmentID:name
 ```shell
 terraform import portainer_kubernetes_namespace.example 1:my-namespace
 ```
+
+After import, set `annotations` and `resource_quota` in config to match the live namespace — Read only restores `name`/`owner` (when set) reliably. The live namespace may include system-managed annotations that are never written back to state, so `annotations` in config stays the source of truth.

--- a/docs/resources/kubernetes_namespace.md
+++ b/docs/resources/kubernetes_namespace.md
@@ -58,3 +58,11 @@ resource "portainer_kubernetes_namespace" "test" {
 | Name  | Description                                  |
 |-------|----------------------------------------------|
 | `id`  | Composite ID in format `environmentID:name`  |
+
+## Import
+
+Kubernetes namespaces can be imported using the composite ID `environmentID:name`:
+
+```shell
+terraform import portainer_kubernetes_namespace.example 1:my-namespace
+```

--- a/docs/resources/kubernetes_namespace_system.md
+++ b/docs/resources/kubernetes_namespace_system.md
@@ -30,3 +30,11 @@ resource "portainer_kubernetes_namespace_system" "system_flag" {
 | Name  | Description                                              |
 |-------|----------------------------------------------------------|
 | `id`  | Composite ID in format `environment_id:namespace`.       |
+
+## Import
+
+Kubernetes namespace system flag resources can be imported using the composite ID `environmentID:namespace`:
+
+```shell
+terraform import portainer_kubernetes_namespace_system.example 1:kube-system
+```

--- a/docs/resources/kubernetes_role.md
+++ b/docs/resources/kubernetes_role.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:role:name    |
+
+## Import
+
+Kubernetes Role resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_role.example 1:default:my-role
+```

--- a/docs/resources/kubernetes_role.md
+++ b/docs/resources/kubernetes_role.md
@@ -53,3 +53,5 @@ Kubernetes Role resources can be imported using the composite ID `endpointID:nam
 ```shell
 terraform import portainer_kubernetes_role.example 1:default:my-role
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_rolebinding.md
+++ b/docs/resources/kubernetes_rolebinding.md
@@ -53,3 +53,5 @@ Kubernetes RoleBinding resources can be imported using the composite ID `endpoin
 ```shell
 terraform import portainer_kubernetes_rolebinding.example 1:default:my-rolebinding
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_rolebinding.md
+++ b/docs/resources/kubernetes_rolebinding.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:rolebinding:name    |
+
+## Import
+
+Kubernetes RoleBinding resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_rolebinding.example 1:default:my-rolebinding
+```

--- a/docs/resources/kubernetes_secret.md
+++ b/docs/resources/kubernetes_secret.md
@@ -53,3 +53,5 @@ Kubernetes Secret resources can be imported using the composite ID `endpointID:n
 ```shell
 terraform import portainer_kubernetes_secret.example 1:default:my-secret
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_secret.md
+++ b/docs/resources/kubernetes_secret.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:secret:name    |
+
+## Import
+
+Kubernetes Secret resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_secret.example 1:default:my-secret
+```

--- a/docs/resources/kubernetes_service.md
+++ b/docs/resources/kubernetes_service.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:service:name    |
+
+## Import
+
+Kubernetes Service resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_service.example 1:default:my-service
+```

--- a/docs/resources/kubernetes_service.md
+++ b/docs/resources/kubernetes_service.md
@@ -53,3 +53,5 @@ Kubernetes Service resources can be imported using the composite ID `endpointID:
 ```shell
 terraform import portainer_kubernetes_service.example 1:default:my-service
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_serviceaccounts.md
+++ b/docs/resources/kubernetes_serviceaccounts.md
@@ -53,3 +53,5 @@ Kubernetes ServiceAccount resources can be imported using the composite ID `endp
 ```shell
 terraform import portainer_kubernetes_serviceaccounts.example 1:default:my-serviceaccount
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_serviceaccounts.md
+++ b/docs/resources/kubernetes_serviceaccounts.md
@@ -45,3 +45,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:serviceaccount:name    |
+
+## Import
+
+Kubernetes ServiceAccount resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_serviceaccounts.example 1:default:my-serviceaccount
+```

--- a/docs/resources/kubernetes_storage.md
+++ b/docs/resources/kubernetes_storage.md
@@ -51,3 +51,5 @@ Kubernetes StorageClass resources can be imported using the composite ID `endpoi
 ```shell
 terraform import portainer_kubernetes_storage.example 1:my-storageclass
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the resource exists and restores identity fields, it does not reconstruct the manifest. If `manifest` is left blank after import, the next `terraform apply` will treat it as a change and may recreate the resource.

--- a/docs/resources/kubernetes_storage.md
+++ b/docs/resources/kubernetes_storage.md
@@ -43,3 +43,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:storage:name    |
+
+## Import
+
+Kubernetes StorageClass resources can be imported using the composite ID `endpointID:name`:
+
+```shell
+terraform import portainer_kubernetes_storage.example 1:my-storageclass
+```

--- a/docs/resources/kubernetes_volume.md
+++ b/docs/resources/kubernetes_volume.md
@@ -74,3 +74,11 @@ terraform destroy
 | Name | Description                               |
 |------|-------------------------------------------|
 | `id` | 	ID in the format endpoint_id:namespace:volumee:name    |
+
+## Import
+
+Kubernetes PersistentVolumeClaim resources can be imported using the composite ID `endpointID:namespace:name`:
+
+```shell
+terraform import portainer_kubernetes_volume.example 1:default:my-pvc
+```

--- a/docs/resources/kubernetes_volume.md
+++ b/docs/resources/kubernetes_volume.md
@@ -77,8 +77,10 @@ terraform destroy
 
 ## Import
 
-Kubernetes PersistentVolumeClaim resources can be imported using the composite ID `endpointID:namespace:name`:
+Kubernetes volume resources can be imported using the composite ID `endpointID:namespace:type:name` (namespace is empty for cluster-scoped types like `persistent-volume`):
 
 ```shell
-terraform import portainer_kubernetes_volume.example 1:default:my-pvc
+terraform import portainer_kubernetes_volume.example 1:default:persistent-volume-claim:my-pvc
 ```
+
+After import, set the `manifest` field in config to match the live object — Read only confirms the volume exists and restores `endpoint_id`/`namespace`/`type`, it does not reconstruct the manifest from the live resource.

--- a/internal/resource_kubernetes_application.go
+++ b/internal/resource_kubernetes_application.go
@@ -173,8 +173,12 @@ func resourceKubernetesApplicationRead(ctx context.Context, d *schema.ResourceDa
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_application.go
+++ b/internal/resource_kubernetes_application.go
@@ -21,6 +21,10 @@ func resourceKubernetesApplication() *schema.Resource {
 		UpdateContext: resourceKubernetesApplicationUpdate,
 		DeleteContext: resourceKubernetesApplicationDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
@@ -154,6 +158,24 @@ func resourceKubernetesApplicationUpdate(ctx context.Context, d *schema.Resource
 }
 
 func resourceKubernetesApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseApllicationsID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/apps/v1/namespaces/%s/deployments/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "deployment "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_application_test.go
+++ b/internal/resource_kubernetes_application_test.go
@@ -135,3 +135,20 @@ func TestKubernetesApplicationRead_Noop(t *testing.T) {
 		t.Fatalf("Read should be a no-op, got error: %v", err)
 	}
 }
+
+func TestKubernetesApplicationRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/apps/v1/namespaces/default/deployments/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesApplication()
+	d := r.TestResourceData()
+	d.SetId("1:default:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_clusterrole.go
+++ b/internal/resource_kubernetes_clusterrole.go
@@ -20,6 +20,10 @@ func resourceKubernetesClusterRoles() *schema.Resource {
 		UpdateContext: resourceKubernetesClusterRolesUpdate,
 		DeleteContext: resourceKubernetesClusterRolesDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -133,6 +137,23 @@ func resourceKubernetesClusterRolesUpdate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceKubernetesClusterRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, name := parseClusterRolesID(d.Id())
+	if endpointID == 0 || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterroles/%s", client.Endpoint, endpointID, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "clusterrole "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_clusterrole.go
+++ b/internal/resource_kubernetes_clusterrole.go
@@ -152,7 +152,9 @@ func resourceKubernetesClusterRolesRead(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_clusterrole_cov_test.go
+++ b/internal/resource_kubernetes_clusterrole_cov_test.go
@@ -50,6 +50,8 @@ func TestKubernetesClusterRoleCreate_MissingName(t *testing.T) {
 // TestKubernetesClusterRoleReadNoop covers the no-op Read handler.
 func TestKubernetesClusterRoleReadNoop(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterroles/cluster-reader",
+		RespondString(http.StatusOK, "application/json", "{}"))
 
 	r := resourceKubernetesClusterRoles()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_clusterrole_cov_test.go
+++ b/internal/resource_kubernetes_clusterrole_cov_test.go
@@ -137,3 +137,23 @@ func TestKubernetesClusterRoleParseID_ThreeParts(t *testing.T) {
 		t.Errorf("expected (2, foo), got (%d, %q)", endpointID, name)
 	}
 }
+
+// TestKubernetesClusterRoleRead_404ClearsID verifies out-of-band deletion is
+// detected: a 404 from the live cluster clears the resource ID so the next
+// plan recreates it.
+func TestKubernetesClusterRoleRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterroles/gone",
+		RespondString(http.StatusNotFound, "application/json", `{"message":"not found"}`))
+
+	r := resourceKubernetesClusterRoles()
+	d := r.TestResourceData()
+	d.SetId("1:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_clusterrolebinding.go
+++ b/internal/resource_kubernetes_clusterrolebinding.go
@@ -20,6 +20,10 @@ func resourceKubernetesClusterRoleBindings() *schema.Resource {
 		UpdateContext: resourceKubernetesClusterRoleBindingsUpdate,
 		DeleteContext: resourceKubernetesClusterRoleBindingsDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -133,6 +137,23 @@ func resourceKubernetesClusterRoleBindingsUpdate(ctx context.Context, d *schema.
 }
 
 func resourceKubernetesClusterRoleBindingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, name := parseClusterRolesBindingsID(d.Id())
+	if endpointID == 0 || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/%s", client.Endpoint, endpointID, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "clusterrolebinding "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_clusterrolebinding.go
+++ b/internal/resource_kubernetes_clusterrolebinding.go
@@ -152,7 +152,9 @@ func resourceKubernetesClusterRoleBindingsRead(ctx context.Context, d *schema.Re
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_clusterrolebinding_cov_test.go
+++ b/internal/resource_kubernetes_clusterrolebinding_cov_test.go
@@ -111,3 +111,23 @@ func TestKubernetesClusterRoleBindingParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values on malformed ID, got (%d, %q)", endpointID, name)
 	}
 }
+
+// TestKubernetesClusterRoleBindingRead_404ClearsID verifies out-of-band
+// deletion is detected: a 404 from the live cluster clears the resource ID
+// so the next plan recreates it.
+func TestKubernetesClusterRoleBindingRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/gone",
+		RespondString(http.StatusNotFound, "application/json", `{"message":"not found"}`))
+
+	r := resourceKubernetesClusterRoleBindings()
+	d := r.TestResourceData()
+	d.SetId("1:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_clusterrolebinding_cov_test.go
+++ b/internal/resource_kubernetes_clusterrolebinding_cov_test.go
@@ -53,6 +53,8 @@ func TestKubernetesClusterRoleBindingCreate_HTTPError(t *testing.T) {
 // TestKubernetesClusterRoleBindingReadNoop covers the no-op Read handler.
 func TestKubernetesClusterRoleBindingReadNoop(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/global-admin",
+		RespondString(http.StatusOK, "application/json", "{}"))
 
 	r := resourceKubernetesClusterRoleBindings()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_common.go
+++ b/internal/resource_kubernetes_common.go
@@ -1,0 +1,59 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// k8sConfirmExistsByGET issues a GET against a manifest-based Kubernetes resource to
+// verify it still exists. On HTTP 404 it clears the resource ID via d.SetId("") so the
+// next plan recreates it (out-of-band deletion detection). On any other non-2xx it
+// returns diagnostics carrying the response body.
+//
+// It deliberately does NOT refresh the authored "manifest" field. The Kubernetes API
+// returns a fully server-expanded object (status, managedFields, resourceVersion,
+// defaulted spec fields, …) that never matches the user's hand-written manifest;
+// writing it back would produce a permanent diff. Since these resources' Update is
+// delete+recreate, that diff would also churn the workload on every apply. So the
+// authored manifest stays the source of truth in state — Read only confirms existence
+// and (in the caller) recovers identity fields. Manifest-content drift is therefore
+// not detected; only deletion is. After `terraform import`, the manifest field must be
+// set in config to match the live object.
+//
+// Returns nil diagnostics with the ID preserved when the object exists, or nil
+// diagnostics with the ID cleared when it is gone. Callers should check d.Id() == ""
+// before setting any other fields.
+func k8sConfirmExistsByGET(ctx context.Context, d *schema.ResourceData, client *APIClient, url, kind string) diag.Diagnostics {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if client.APIKey != "" {
+		req.Header.Set("X-API-Key", client.APIKey)
+	} else if client.JWTToken != "" {
+		req.Header.Set("Authorization", "Bearer "+client.JWTToken)
+	} else {
+		return diag.FromErr(fmt.Errorf("no valid authentication method provided (api_key or jwt token)"))
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return diag.FromErr(fmt.Errorf("failed to read %s (%d): %s", kind, resp.StatusCode, string(body)))
+	}
+	return nil
+}

--- a/internal/resource_kubernetes_configmaps.go
+++ b/internal/resource_kubernetes_configmaps.go
@@ -158,8 +158,12 @@ func resourceKubernetesConfigMapsRead(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_configmaps.go
+++ b/internal/resource_kubernetes_configmaps.go
@@ -20,6 +20,10 @@ func resourceKubernetesConfigMaps() *schema.Resource {
 		UpdateContext: resourceKubernetesConfigMapsUpdate,
 		DeleteContext: resourceKubernetesConfigMapsDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesConfigMapsUpdate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceKubernetesConfigMapsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseConfigMapsID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/api/v1/namespaces/%s/configmaps/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "configmap "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_configmaps_cov_test.go
+++ b/internal/resource_kubernetes_configmaps_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesConfigMapsDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesConfigMapsRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/configmaps/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesConfigMaps()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_configmaps_cov_test.go
+++ b/internal/resource_kubernetes_configmaps_cov_test.go
@@ -101,3 +101,20 @@ func TestKubernetesConfigMapsCreate_MissingMetadataName(t *testing.T) {
 		t.Fatal("expected error for missing metadata.name")
 	}
 }
+
+func TestKubernetesConfigMapsRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/configmaps/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesConfigMaps()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_cronjob.go
+++ b/internal/resource_kubernetes_cronjob.go
@@ -158,8 +158,12 @@ func resourceKubernetesCronJobRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_cronjob.go
+++ b/internal/resource_kubernetes_cronjob.go
@@ -20,6 +20,10 @@ func resourceKubernetesCronJob() *schema.Resource {
 		UpdateContext: resourceKubernetesCronJobUpdate,
 		DeleteContext: resourceKubernetesCronJobDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesCronJobUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceKubernetesCronJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseCronJobID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/batch/v1/namespaces/%s/cronjobs/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "cronjob "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_cronjob_cov_test.go
+++ b/internal/resource_kubernetes_cronjob_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesCronJobDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesCronJobRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/batch/v1/namespaces/ns/cronjobs/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesCronJob()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_cronjob_cov_test.go
+++ b/internal/resource_kubernetes_cronjob_cov_test.go
@@ -108,3 +108,20 @@ func TestKubernetesCronJobParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesCronJobRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/batch/v1/namespaces/ns/cronjobs/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesCronJob()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_helm.go
+++ b/internal/resource_kubernetes_helm.go
@@ -170,14 +170,24 @@ func resourceKubernetesHelmRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(fmt.Errorf("failed to decode helm release response: %w", err))
 	}
 
-	d.Set("environment_id", envID)
-	d.Set("namespace", namespace)
-	d.Set("name", release)
+	if err := d.Set("environment_id", envID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", release); err != nil {
+		return diag.FromErr(err)
+	}
 	if helmRelease.ChartReference.ChartPath != "" {
-		d.Set("chart", helmRelease.ChartReference.ChartPath)
+		if err := d.Set("chart", helmRelease.ChartReference.ChartPath); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if helmRelease.ChartReference.RepoURL != "" {
-		d.Set("repo", helmRelease.ChartReference.RepoURL)
+		if err := d.Set("repo", helmRelease.ChartReference.RepoURL); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	// values not restored — the API returns server-merged computed values, not the
 	// original user-supplied YAML. Keep whatever is currently in state; users with

--- a/internal/resource_kubernetes_helm.go
+++ b/internal/resource_kubernetes_helm.go
@@ -160,16 +160,6 @@ func resourceKubernetesHelmRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(fmt.Errorf("failed to read helm release %s (%d): %s", release, resp.StatusCode, string(body)))
 	}
 
-	var helmRelease struct {
-		ChartReference struct {
-			ChartPath string `json:"chartPath"`
-			RepoURL   string `json:"repoURL"`
-		} `json:"chartReference"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&helmRelease); err != nil {
-		return diag.FromErr(fmt.Errorf("failed to decode helm release response: %w", err))
-	}
-
 	if err := d.Set("environment_id", envID); err != nil {
 		return diag.FromErr(err)
 	}
@@ -179,19 +169,12 @@ func resourceKubernetesHelmRead(ctx context.Context, d *schema.ResourceData, met
 	if err := d.Set("name", release); err != nil {
 		return diag.FromErr(err)
 	}
-	if helmRelease.ChartReference.ChartPath != "" {
-		if err := d.Set("chart", helmRelease.ChartReference.ChartPath); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-	if helmRelease.ChartReference.RepoURL != "" {
-		if err := d.Set("repo", helmRelease.ChartReference.RepoURL); err != nil {
-			return diag.FromErr(err)
-		}
-	}
-	// values not restored — the API returns server-merged computed values, not the
-	// original user-supplied YAML. Keep whatever is currently in state; users with
-	// custom values should add lifecycle { ignore_changes = [values] } after import.
+	// chart/repo/values intentionally not refreshed — the release detail API returns a
+	// server-normalised chartReference (chartPath/repoURL) that may not byte-match the
+	// user's authored config, and chart/repo are ForceNew: any mismatch would trigger a
+	// destroy+recreate instead of a benign diff. Read only confirms the release exists
+	// and restores identity fields. After `terraform import`, chart/repo/values must be
+	// set in config to match the live release or the next apply recreates it.
 	return nil
 }
 

--- a/internal/resource_kubernetes_helm.go
+++ b/internal/resource_kubernetes_helm.go
@@ -20,6 +20,10 @@ func resourceKubernetesHelm() *schema.Resource {
 		ReadContext:   resourceKubernetesHelmRead,
 		DeleteContext: resourceKubernetesHelmDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(15 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
@@ -114,7 +118,70 @@ func resourceKubernetesHelmCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceKubernetesHelmRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// No-op for now
+	client := meta.(*APIClient)
+
+	idParts := strings.SplitN(d.Id(), ":", 3)
+	if len(idParts) != 3 {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace:release': %s", d.Id()))
+	}
+	var envID int
+	fmt.Sscanf(idParts[0], "%d", &envID)
+	namespace := idParts[1]
+	release := idParts[2]
+	if envID == 0 || release == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace:release': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/helm/%s?namespace=%s", client.Endpoint, envID, release, namespace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if client.APIKey != "" {
+		req.Header.Set("X-API-Key", client.APIKey)
+	} else if client.JWTToken != "" {
+		req.Header.Set("Authorization", "Bearer "+client.JWTToken)
+	} else {
+		return diag.FromErr(fmt.Errorf("no valid authentication method provided (api_key or jwt token)"))
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return diag.FromErr(fmt.Errorf("failed to read helm release %s (%d): %s", release, resp.StatusCode, string(body)))
+	}
+
+	var helmRelease struct {
+		ChartReference struct {
+			ChartPath string `json:"chartPath"`
+			RepoURL   string `json:"repoURL"`
+		} `json:"chartReference"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&helmRelease); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to decode helm release response: %w", err))
+	}
+
+	d.Set("environment_id", envID)
+	d.Set("namespace", namespace)
+	d.Set("name", release)
+	if helmRelease.ChartReference.ChartPath != "" {
+		d.Set("chart", helmRelease.ChartReference.ChartPath)
+	}
+	if helmRelease.ChartReference.RepoURL != "" {
+		d.Set("repo", helmRelease.ChartReference.RepoURL)
+	}
+	// values not restored — the API returns server-merged computed values, not the
+	// original user-supplied YAML. Keep whatever is currently in state; users with
+	// custom values should add lifecycle { ignore_changes = [values] } after import.
 	return nil
 }
 

--- a/internal/resource_kubernetes_helm_test.go
+++ b/internal/resource_kubernetes_helm_test.go
@@ -12,6 +12,12 @@ func TestKubernetesHelmCreate_HappyPath(t *testing.T) {
 	mock := NewMockServer(t)
 
 	mock.On("POST", "/endpoints/3/kubernetes/helm", RespondJSON(http.StatusCreated, map[string]interface{}{}))
+	mock.On("GET", "/endpoints/3/kubernetes/helm/my-nginx", RespondJSON(http.StatusOK, map[string]interface{}{
+		"chartReference": map[string]interface{}{
+			"chartPath": "nginx",
+			"repoURL":   "https://charts.bitnami.com/bitnami",
+		},
+	}))
 
 	r := resourceKubernetesHelm()
 	d := r.TestResourceData()
@@ -108,6 +114,8 @@ func TestKubernetesHelmDelete_HappyPath(t *testing.T) {
 // TestKubernetesHelmRead_Noop verifies Read is a no-op.
 func TestKubernetesHelmRead_Noop(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/3/kubernetes/helm/my-nginx",
+		RespondJSON(http.StatusOK, map[string]interface{}{"chartReference": map[string]interface{}{"chartPath": "nginx", "repoURL": "https://charts.bitnami.com/bitnami"}}))
 
 	r := resourceKubernetesHelm()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_helm_test.go
+++ b/internal/resource_kubernetes_helm_test.go
@@ -125,3 +125,20 @@ func TestKubernetesHelmRead_Noop(t *testing.T) {
 		t.Fatalf("Read should be a no-op, got error: %v", err)
 	}
 }
+
+func TestKubernetesHelmRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/helm/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesHelm()
+	d := r.TestResourceData()
+	d.SetId("1:default:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_ingresses.go
+++ b/internal/resource_kubernetes_ingresses.go
@@ -20,6 +20,10 @@ func resourceKubernetesNamespaceIngress() *schema.Resource {
 		UpdateContext: resourceKubernetesNamespaceIngressUpdate,
 		DeleteContext: resourceKubernetesNamespaceIngressDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"environment_id": {
 				Type:        schema.TypeInt,
@@ -215,7 +219,37 @@ func createOrUpdateIngress(ctx context.Context, d *schema.ResourceData, client *
 }
 
 func resourceKubernetesNamespaceIngressRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil // No-op
+	client := meta.(*APIClient)
+
+	parts := strings.SplitN(d.Id(), ":", 3)
+	if len(parts) != 3 {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace:name': %s", d.Id()))
+	}
+	var envID int
+	fmt.Sscanf(parts[0], "%d", &envID)
+	namespace := parts[1]
+	name := parts[2]
+	if envID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace:name': %s", d.Id()))
+	}
+
+	// Existence check via the K8s proxy (standard networking.k8s.io path) for clean 404s.
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/networking.k8s.io/v1/namespaces/%s/ingresses/%s", client.Endpoint, envID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "ingress "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("environment_id", envID)
+	d.Set("namespace", namespace)
+	d.Set("name", name)
+	// Nested spec (hosts/tls/paths/annotations/labels/class_name) intentionally not
+	// refreshed — reconstructing it from the live Ingress object is lossy and would diff
+	// against the authored config. The config stays the source of truth; only deletion is
+	// detected. After `terraform import`, set those fields to match.
+	return nil
 }
 
 func resourceKubernetesNamespaceIngressDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resource_kubernetes_ingresses.go
+++ b/internal/resource_kubernetes_ingresses.go
@@ -242,9 +242,15 @@ func resourceKubernetesNamespaceIngressRead(ctx context.Context, d *schema.Resou
 		return nil
 	}
 
-	d.Set("environment_id", envID)
-	d.Set("namespace", namespace)
-	d.Set("name", name)
+	if err := d.Set("environment_id", envID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", name); err != nil {
+		return diag.FromErr(err)
+	}
 	// Nested spec (hosts/tls/paths/annotations/labels/class_name) intentionally not
 	// refreshed — reconstructing it from the live Ingress object is lossy and would diff
 	// against the authored config. The config stays the source of truth; only deletion is

--- a/internal/resource_kubernetes_ingresses_test.go
+++ b/internal/resource_kubernetes_ingresses_test.go
@@ -112,3 +112,20 @@ func TestKubernetesIngressDelete_NoOp(t *testing.T) {
 		t.Errorf("expected no requests for no-op Delete, got %d", len(reqs))
 	}
 }
+
+func TestKubernetesNamespaceIngressRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/networking.k8s.io/v1/namespaces/default/ingresses/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesNamespaceIngress()
+	d := r.TestResourceData()
+	d.SetId("1:default:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_job.go
+++ b/internal/resource_kubernetes_job.go
@@ -20,6 +20,10 @@ func resourceKubernetesJob() *schema.Resource {
 		UpdateContext: resourceKubernetesJobUpdate,
 		DeleteContext: resourceKubernetesJobDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesJobUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceKubernetesJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseJobID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/batch/v1/namespaces/%s/jobs/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "job "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_job.go
+++ b/internal/resource_kubernetes_job.go
@@ -158,8 +158,12 @@ func resourceKubernetesJobRead(ctx context.Context, d *schema.ResourceData, meta
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_job_cov_test.go
+++ b/internal/resource_kubernetes_job_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesJobDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesJobRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/batch/v1/namespaces/ns/jobs/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesJob()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_job_cov_test.go
+++ b/internal/resource_kubernetes_job_cov_test.go
@@ -108,3 +108,20 @@ func TestKubernetesJobParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesJobRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/batch/v1/namespaces/ns/jobs/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesJob()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_namespace.go
+++ b/internal/resource_kubernetes_namespace.go
@@ -181,9 +181,8 @@ func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData
 	}
 
 	var ns struct {
-		Name           string            `json:"Name"`
-		NamespaceOwner string            `json:"NamespaceOwner"`
-		Annotations    map[string]string `json:"Annotations"`
+		Name           string `json:"Name"`
+		NamespaceOwner string `json:"NamespaceOwner"`
 		ResourceQuota  *struct {
 			Spec struct {
 				Hard map[string]string `json:"hard"`
@@ -209,15 +208,12 @@ func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if ns.Annotations != nil {
-		if err := d.Set("annotations", ns.Annotations); err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		if err := d.Set("annotations", map[string]string{}); err != nil {
-			return diag.FromErr(err)
-		}
-	}
+	// annotations intentionally not refreshed — the live namespace object includes
+	// system-managed annotations the user never authored (e.g.
+	// kubectl.kubernetes.io/last-applied-configuration, controller-injected keys).
+	// Writing the full server map back into state would produce a permanent diff
+	// against the user's config. The authored annotations stay the source of truth;
+	// after `terraform import`, set this field in config to match what's live.
 
 	// Map the K8s ResourceQuota spec.hard keys ("limits.cpu", "requests.memory", …) back
 	// to the friendlier schema keys (cpu_limit, memory_limit, cpu_request, memory_request).

--- a/internal/resource_kubernetes_namespace.go
+++ b/internal/resource_kubernetes_namespace.go
@@ -22,6 +22,10 @@ func resourceKubernetesNamespace() *schema.Resource {
 		UpdateContext: resourceKubernetesNamespaceUpdate,
 		DeleteContext: resourceKubernetesNamespaceDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"environment_id": {
 				Type:        schema.TypeInt,
@@ -135,7 +139,101 @@ func resourceKubernetesNamespaceCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// No-op for now
+	client := meta.(*APIClient)
+
+	idParts := strings.SplitN(d.Id(), ":", 2)
+	if len(idParts) != 2 {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:name': %s", d.Id()))
+	}
+	envID, err := strconv.Atoi(idParts[0])
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("invalid environment ID in resource ID %q: %w", d.Id(), err))
+	}
+	name := idParts[1]
+
+	url := fmt.Sprintf("%s/kubernetes/%d/namespaces/%s?withResourceQuota=true", client.Endpoint, envID, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if client.APIKey != "" {
+		req.Header.Set("X-API-Key", client.APIKey)
+	} else if client.JWTToken != "" {
+		req.Header.Set("Authorization", "Bearer "+client.JWTToken)
+	} else {
+		return diag.FromErr(fmt.Errorf("no valid authentication method provided (api_key or jwt token)"))
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	// Namespace deleted out-of-band — clear from state so the next plan recreates.
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		data, _ := io.ReadAll(resp.Body)
+		return diag.FromErr(fmt.Errorf("failed to read namespace %q: %s", name, string(data)))
+	}
+
+	var ns struct {
+		Name           string            `json:"Name"`
+		NamespaceOwner string            `json:"NamespaceOwner"`
+		Annotations    map[string]string `json:"Annotations"`
+		ResourceQuota  *struct {
+			Spec struct {
+				Hard map[string]string `json:"hard"`
+			} `json:"spec"`
+		} `json:"ResourceQuota"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ns); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to decode namespace response: %w", err))
+	}
+
+	d.Set("environment_id", envID)
+	d.Set("name", ns.Name)
+	// NamespaceOwner is a Portainer-level label the API does not reliably persist back —
+	// GET returns "" even when the namespace was created with an owner. Only overwrite
+	// state when the API returns something, so we don't generate permanent drift.
+	if ns.NamespaceOwner != "" {
+		d.Set("owner", ns.NamespaceOwner)
+	}
+
+	if ns.Annotations != nil {
+		d.Set("annotations", ns.Annotations)
+	} else {
+		d.Set("annotations", map[string]string{})
+	}
+
+	// Map the K8s ResourceQuota spec.hard keys ("limits.cpu", "requests.memory", …) back
+	// to the friendlier schema keys (cpu_limit, memory_limit, cpu_request, memory_request).
+	// When EnableResourceOverCommit is true Portainer does not persist quotas and the API
+	// returns an empty spec.hard; skip d.Set in that case so the authored quota stays in
+	// state and does not generate permanent drift on over-commit environments.
+	quota := map[string]string{}
+	if ns.ResourceQuota != nil {
+		hard := ns.ResourceQuota.Spec.Hard
+		if v, ok := hard["limits.cpu"]; ok {
+			quota["cpu_limit"] = v
+		}
+		if v, ok := hard["limits.memory"]; ok {
+			quota["memory_limit"] = v
+		}
+		if v, ok := hard["requests.cpu"]; ok {
+			quota["cpu_request"] = v
+		}
+		if v, ok := hard["requests.memory"]; ok {
+			quota["memory_request"] = v
+		}
+	}
+	if len(quota) > 0 {
+		d.Set("resource_quota", quota)
+	}
+
 	return nil
 }
 

--- a/internal/resource_kubernetes_namespace.go
+++ b/internal/resource_kubernetes_namespace.go
@@ -194,19 +194,29 @@ func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("failed to decode namespace response: %w", err))
 	}
 
-	d.Set("environment_id", envID)
-	d.Set("name", ns.Name)
+	if err := d.Set("environment_id", envID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("name", ns.Name); err != nil {
+		return diag.FromErr(err)
+	}
 	// NamespaceOwner is a Portainer-level label the API does not reliably persist back —
 	// GET returns "" even when the namespace was created with an owner. Only overwrite
 	// state when the API returns something, so we don't generate permanent drift.
 	if ns.NamespaceOwner != "" {
-		d.Set("owner", ns.NamespaceOwner)
+		if err := d.Set("owner", ns.NamespaceOwner); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if ns.Annotations != nil {
-		d.Set("annotations", ns.Annotations)
+		if err := d.Set("annotations", ns.Annotations); err != nil {
+			return diag.FromErr(err)
+		}
 	} else {
-		d.Set("annotations", map[string]string{})
+		if err := d.Set("annotations", map[string]string{}); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	// Map the K8s ResourceQuota spec.hard keys ("limits.cpu", "requests.memory", …) back
@@ -231,7 +241,9 @@ func resourceKubernetesNamespaceRead(ctx context.Context, d *schema.ResourceData
 		}
 	}
 	if len(quota) > 0 {
-		d.Set("resource_quota", quota)
+		if err := d.Set("resource_quota", quota); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	return nil

--- a/internal/resource_kubernetes_namespace_system.go
+++ b/internal/resource_kubernetes_namespace_system.go
@@ -134,9 +134,15 @@ func resourceKubernetesNamespaceSystemRead(ctx context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("failed to decode namespace response: %w", err))
 	}
 
-	d.Set("environment_id", envID)
-	d.Set("namespace", namespace)
-	d.Set("system", ns.IsSystem)
+	if err := d.Set("environment_id", envID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("system", ns.IsSystem); err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/internal/resource_kubernetes_namespace_system.go
+++ b/internal/resource_kubernetes_namespace_system.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,6 +19,10 @@ func resourceKubernetesNamespaceSystem() *schema.Resource {
 		ReadContext:   resourceKubernetesNamespaceSystemRead,
 		UpdateContext: resourceKubernetesNamespaceSystemToggle,
 		DeleteContext: resourceKubernetesNamespaceSystemUnset,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"environment_id": {
@@ -81,6 +86,57 @@ func resourceKubernetesNamespaceSystemToggle(ctx context.Context, d *schema.Reso
 }
 
 func resourceKubernetesNamespaceSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	parts := strings.SplitN(d.Id(), ":", 2)
+	if len(parts) != 2 {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace': %s", d.Id()))
+	}
+	var envID int
+	fmt.Sscanf(parts[0], "%d", &envID)
+	namespace := parts[1]
+	if envID == 0 || namespace == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'envID:namespace': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/kubernetes/%d/namespaces/%s", client.Endpoint, envID, namespace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if client.APIKey != "" {
+		req.Header.Set("X-API-Key", client.APIKey)
+	} else if client.JWTToken != "" {
+		req.Header.Set("Authorization", "Bearer "+client.JWTToken)
+	} else {
+		return diag.FromErr(fmt.Errorf("no valid authentication method provided (api_key or jwt token)"))
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		data, _ := io.ReadAll(resp.Body)
+		return diag.FromErr(fmt.Errorf("failed to read namespace %q: %s", namespace, string(data)))
+	}
+
+	var ns struct {
+		IsSystem bool `json:"IsSystem"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ns); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to decode namespace response: %w", err))
+	}
+
+	d.Set("environment_id", envID)
+	d.Set("namespace", namespace)
+	d.Set("system", ns.IsSystem)
 	return nil
 }
 

--- a/internal/resource_kubernetes_namespace_system_cov2_test.go
+++ b/internal/resource_kubernetes_namespace_system_cov2_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -8,6 +9,8 @@ import (
 // (returns nil and touches no endpoint).
 func TestKubernetesNamespaceSystemCov2_Read_NoOp(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/kubernetes/1/namespaces/kube-system",
+		RespondJSON(http.StatusOK, map[string]interface{}{"IsSystem": false}))
 
 	r := resourceKubernetesNamespaceSystem()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_namespace_system_test.go
+++ b/internal/resource_kubernetes_namespace_system_test.go
@@ -121,3 +121,20 @@ func TestKubernetesNamespaceSystemCreate_HTTPError(t *testing.T) {
 		t.Errorf("expected empty ID after error, got %q", d.Id())
 	}
 }
+
+func TestKubernetesNamespaceSystemRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/kubernetes/1/namespaces/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesNamespaceSystem()
+	d := r.TestResourceData()
+	d.SetId("1:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_namespace_test.go
+++ b/internal/resource_kubernetes_namespace_test.go
@@ -198,3 +198,20 @@ func TestKubernetesNamespaceDelete_HappyPath(t *testing.T) {
 		t.Errorf("expected ID cleared, got %q", d.Id())
 	}
 }
+
+func TestKubernetesNamespaceRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/kubernetes/1/namespaces/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesNamespace()
+	d := r.TestResourceData()
+	d.SetId("1:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_namespace_test.go
+++ b/internal/resource_kubernetes_namespace_test.go
@@ -14,6 +14,7 @@ func TestKubernetesNamespaceCreate_HappyPath_Unlicensed(t *testing.T) {
 	// Unlicensed: /licenses returns empty list.
 	mock.On("GET", "/licenses", RespondJSON(http.StatusOK, []map[string]interface{}{}))
 	mock.On("POST", "/kubernetes/1/namespaces", RespondJSON(http.StatusOK, map[string]interface{}{}))
+	mock.On("GET", "/kubernetes/1/namespaces/my-ns", RespondJSON(http.StatusOK, map[string]interface{}{"Name": "my-ns"}))
 
 	r := resourceKubernetesNamespace()
 	d := r.TestResourceData()
@@ -70,6 +71,7 @@ func TestKubernetesNamespaceCreate_HappyPath_Licensed(t *testing.T) {
 		{"id": 1, "company": "ACME"},
 	}))
 	mock.On("POST", "/kubernetes/2/namespaces", RespondJSON(http.StatusOK, map[string]interface{}{}))
+	mock.On("GET", "/kubernetes/2/namespaces/team-a", RespondJSON(http.StatusOK, map[string]interface{}{"Name": "team-a"}))
 
 	r := resourceKubernetesNamespace()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_role.go
+++ b/internal/resource_kubernetes_role.go
@@ -20,6 +20,10 @@ func resourceKubernetesRoles() *schema.Resource {
 		UpdateContext: resourceKubernetesRolesUpdate,
 		DeleteContext: resourceKubernetesRolesDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesRolesUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceKubernetesRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseRolesID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/%s/roles/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "role "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_role.go
+++ b/internal/resource_kubernetes_role.go
@@ -158,8 +158,12 @@ func resourceKubernetesRolesRead(ctx context.Context, d *schema.ResourceData, me
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_role_cov_test.go
+++ b/internal/resource_kubernetes_role_cov_test.go
@@ -53,6 +53,8 @@ func TestKubernetesRoleCreate_MissingName(t *testing.T) {
 // TestKubernetesRoleReadNoop covers the no-op Read handler.
 func TestKubernetesRoleReadNoop(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/default/roles/pod-reader",
+		RespondString(http.StatusOK, "application/json", "{}"))
 
 	r := resourceKubernetesRoles()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_role_cov_test.go
+++ b/internal/resource_kubernetes_role_cov_test.go
@@ -112,3 +112,20 @@ func TestKubernetesRoleParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values on malformed ID, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesRoleRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/default/roles/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesRoles()
+	d := r.TestResourceData()
+	d.SetId("1:default:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_rolebinding.go
+++ b/internal/resource_kubernetes_rolebinding.go
@@ -20,6 +20,10 @@ func resourceKubernetesRoleBindings() *schema.Resource {
 		UpdateContext: resourceKubernetesRoleBindingsUpdate,
 		DeleteContext: resourceKubernetesRoleBindingsDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesRoleBindingsUpdate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceKubernetesRoleBindingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseRoleBindingsID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/%s/rolebindings/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "rolebinding "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_rolebinding.go
+++ b/internal/resource_kubernetes_rolebinding.go
@@ -158,8 +158,12 @@ func resourceKubernetesRoleBindingsRead(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_rolebinding_cov_test.go
+++ b/internal/resource_kubernetes_rolebinding_cov_test.go
@@ -53,6 +53,8 @@ func TestKubernetesRoleBindingCreate_MissingName(t *testing.T) {
 // TestKubernetesRoleBindingReadNoop covers the no-op Read handler.
 func TestKubernetesRoleBindingReadNoop(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/default/rolebindings/read-pods",
+		RespondString(http.StatusOK, "application/json", "{}"))
 
 	r := resourceKubernetesRoleBindings()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_rolebinding_cov_test.go
+++ b/internal/resource_kubernetes_rolebinding_cov_test.go
@@ -131,3 +131,20 @@ func TestKubernetesRoleBindingParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values on malformed ID, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesRoleBindingRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/rbac.authorization.k8s.io/v1/namespaces/default/rolebindings/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesRoleBindings()
+	d := r.TestResourceData()
+	d.SetId("1:default:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_secret.go
+++ b/internal/resource_kubernetes_secret.go
@@ -20,6 +20,10 @@ func resourceKubernetesSecrets() *schema.Resource {
 		UpdateContext: resourceKubernetesSecretsUpdate,
 		DeleteContext: resourceKubernetesSecretsDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesSecretsUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceKubernetesSecretsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseSecretsID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/api/v1/namespaces/%s/secrets/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "secret "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_secret.go
+++ b/internal/resource_kubernetes_secret.go
@@ -158,8 +158,12 @@ func resourceKubernetesSecretsRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_secret_cov_test.go
+++ b/internal/resource_kubernetes_secret_cov_test.go
@@ -108,3 +108,20 @@ func TestKubernetesSecretParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesSecretRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/secrets/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesSecrets()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_secret_cov_test.go
+++ b/internal/resource_kubernetes_secret_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesSecretDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesSecretRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/secrets/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesSecrets()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_service.go
+++ b/internal/resource_kubernetes_service.go
@@ -20,6 +20,10 @@ func resourceKubernetesService() *schema.Resource {
 		UpdateContext: resourceKubernetesServiceUpdate,
 		DeleteContext: resourceKubernetesServiceDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -139,6 +143,24 @@ func resourceKubernetesServiceUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceKubernetesServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseServiceID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/api/v1/namespaces/%s/services/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "service "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_service.go
+++ b/internal/resource_kubernetes_service.go
@@ -158,8 +158,12 @@ func resourceKubernetesServiceRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_service_cov_test.go
+++ b/internal/resource_kubernetes_service_cov_test.go
@@ -108,3 +108,20 @@ func TestKubernetesServiceParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesServiceRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/services/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesService()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_service_cov_test.go
+++ b/internal/resource_kubernetes_service_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesServiceDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesServiceRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/services/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesService()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_serviceaccounts.go
+++ b/internal/resource_kubernetes_serviceaccounts.go
@@ -20,6 +20,10 @@ func resourceKubernetesServiceAccounts() *schema.Resource {
 		UpdateContext: resourceKubernetesServiceAccountsUpdate,
 		DeleteContext: resourceKubernetesServiceAccountsDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -141,6 +145,24 @@ func resourceKubernetesServiceAccountsUpdate(ctx context.Context, d *schema.Reso
 }
 
 func resourceKubernetesServiceAccountsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, namespace, name := parseServiceAccountsID(d.Id())
+	if endpointID == 0 || namespace == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/api/v1/namespaces/%s/serviceaccounts/%s", client.Endpoint, endpointID, namespace, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "serviceaccount "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_serviceaccounts.go
+++ b/internal/resource_kubernetes_serviceaccounts.go
@@ -160,8 +160,12 @@ func resourceKubernetesServiceAccountsRead(ctx context.Context, d *schema.Resour
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_serviceaccounts_cov_test.go
+++ b/internal/resource_kubernetes_serviceaccounts_cov_test.go
@@ -63,10 +63,14 @@ func TestKubernetesServiceAccountDelete_404IsSuccess(t *testing.T) {
 }
 
 func TestKubernetesServiceAccountRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/serviceaccounts/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesServiceAccounts()
 	d := r.TestResourceData()
 	d.SetId("1:ns:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:ns:keep" {

--- a/internal/resource_kubernetes_serviceaccounts_cov_test.go
+++ b/internal/resource_kubernetes_serviceaccounts_cov_test.go
@@ -108,3 +108,20 @@ func TestKubernetesServiceAccountParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q, %q)", endpointID, namespace, name)
 	}
 }
+
+func TestKubernetesServiceAccountRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/ns/serviceaccounts/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesServiceAccounts()
+	d := r.TestResourceData()
+	d.SetId("1:ns:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_storage.go
+++ b/internal/resource_kubernetes_storage.go
@@ -152,7 +152,9 @@ func resourceKubernetesStorageRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_storage.go
+++ b/internal/resource_kubernetes_storage.go
@@ -20,6 +20,10 @@ func resourceKubernetesStorage() *schema.Resource {
 		UpdateContext: resourceKubernetesStorageUpdate,
 		DeleteContext: resourceKubernetesStorageDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -133,6 +137,23 @@ func resourceKubernetesStorageUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceKubernetesStorageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*APIClient)
+
+	endpointID, name := parseStorageID(d.Id())
+	if endpointID == 0 || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:name': %s", d.Id()))
+	}
+
+	url := fmt.Sprintf("%s/endpoints/%d/kubernetes/apis/storage.k8s.io/v1/storageclasses/%s", client.Endpoint, endpointID, name)
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, "storageclass "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_storage_cov_test.go
+++ b/internal/resource_kubernetes_storage_cov_test.go
@@ -73,10 +73,14 @@ func TestKubernetesStorageDelete_404IsSuccess(t *testing.T) {
 
 // TestKubernetesStorageRead_NoOp verifies Read is a no-op returning nil.
 func TestKubernetesStorageRead_NoOp(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/storage.k8s.io/v1/storageclasses/keep",
+		RespondString(http.StatusOK, "application/json", "{}"))
+
 	r := resourceKubernetesStorage()
 	d := r.TestResourceData()
 	d.SetId("1:keep")
-	if err := rcRead(r, d, nil); err != nil {
+	if err := rcRead(r, d, mock.Client()); err != nil {
 		t.Fatalf("Read should be no-op, got %v", err)
 	}
 	if d.Id() != "1:keep" {

--- a/internal/resource_kubernetes_storage_cov_test.go
+++ b/internal/resource_kubernetes_storage_cov_test.go
@@ -131,3 +131,20 @@ func TestKubernetesStorageParseID_Malformed(t *testing.T) {
 		t.Errorf("expected zero values, got (%d, %q)", endpointID, name)
 	}
 }
+
+func TestKubernetesStorageRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/apis/storage.k8s.io/v1/storageclasses/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesStorage()
+	d := r.TestResourceData()
+	d.SetId("1:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_kubernetes_volume.go
+++ b/internal/resource_kubernetes_volume.go
@@ -20,6 +20,10 @@ func resourceKubernetesVolumes() *schema.Resource {
 		UpdateContext: resourceKubernetesVolumesUpdate,
 		DeleteContext: resourceKubernetesVolumesDelete,
 
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"endpoint_id": {
 				Type:        schema.TypeInt,
@@ -162,7 +166,28 @@ func resourceKubernetesVolumesUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceKubernetesVolumesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Optional: implement if needed
+	client := meta.(*APIClient)
+
+	endpointID, namespace, volType, name := parseVolumesID(d.Id())
+	if endpointID == 0 || volType == "" || name == "" {
+		return diag.FromErr(fmt.Errorf("invalid ID format, expected 'endpointID:namespace:type:name': %s", d.Id()))
+	}
+
+	url, err := volumeAPIURL(client.Endpoint, endpointID, namespace, volType, true, name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if diags := k8sConfirmExistsByGET(ctx, d, client, url, volType+" "+name); diags.HasError() {
+		return diags
+	}
+	if d.Id() == "" {
+		return nil
+	}
+
+	d.Set("endpoint_id", endpointID)
+	d.Set("namespace", namespace)
+	d.Set("type", volType)
+	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }
 

--- a/internal/resource_kubernetes_volume.go
+++ b/internal/resource_kubernetes_volume.go
@@ -184,9 +184,15 @@ func resourceKubernetesVolumesRead(ctx context.Context, d *schema.ResourceData, 
 		return nil
 	}
 
-	d.Set("endpoint_id", endpointID)
-	d.Set("namespace", namespace)
-	d.Set("type", volType)
+	if err := d.Set("endpoint_id", endpointID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("namespace", namespace); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("type", volType); err != nil {
+		return diag.FromErr(err)
+	}
 	// "manifest" intentionally not refreshed — see k8sConfirmExistsByGET.
 	return nil
 }

--- a/internal/resource_kubernetes_volume_cov_test.go
+++ b/internal/resource_kubernetes_volume_cov_test.go
@@ -169,6 +169,8 @@ func TestKubernetesVolumesCreate_HTTPError(t *testing.T) {
 // TestKubernetesVolumesRead_NoOp verifies Read is a no-op (returns nil).
 func TestKubernetesVolumesRead_NoOp(t *testing.T) {
 	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/default/persistentvolumeclaims/my-pvc",
+		RespondString(http.StatusOK, "application/json", "{}"))
 
 	r := resourceKubernetesVolumes()
 	d := r.TestResourceData()

--- a/internal/resource_kubernetes_volume_cov_test.go
+++ b/internal/resource_kubernetes_volume_cov_test.go
@@ -235,3 +235,20 @@ func TestKubernetesVolumesDelete_HTTPError(t *testing.T) {
 		t.Fatal("expected error on HTTP 500, got nil")
 	}
 }
+
+func TestKubernetesVolumesRead_404ClearsID(t *testing.T) {
+	mock := NewMockServer(t)
+	mock.On("GET", "/endpoints/1/kubernetes/api/v1/namespaces/default/persistentvolumeclaims/gone",
+		RespondString(http.StatusNotFound, "application/json", "{\"message\":\"not found\"}"))
+
+	r := resourceKubernetesVolumes()
+	d := r.TestResourceData()
+	d.SetId("1:default:persistent-volume-claim:gone")
+
+	if err := rcRead(r, d, mock.Client()); err != nil {
+		t.Fatalf("Read on 404 should not error, got %v", err)
+	}
+	if d.Id() != "" {
+		t.Errorf("expected ID cleared on 404, got %q", d.Id())
+	}
+}

--- a/internal/resource_stack.go
+++ b/internal/resource_stack.go
@@ -445,6 +445,17 @@ func resourcePortainerStackCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	if id := d.Id(); id == "" || id == "0" {
+		resolvedID, lookupErr := findExistingStackByName(ctx, client, name, endpointID)
+		if lookupErr != nil {
+			return diag.FromErr(fmt.Errorf("stack %q was created but its ID could not be resolved by name on endpoint %d: %w", name, endpointID, lookupErr))
+		}
+		if resolvedID == 0 {
+			return diag.FromErr(fmt.Errorf("stack %q was created but could not be found by name on endpoint %d to resolve its ID", name, endpointID))
+		}
+		d.SetId(strconv.Itoa(resolvedID))
+	}
+
 	if method != "repository" {
 		var webhookToken string
 		if d.Get("stack_webhook").(bool) {

--- a/internal/resource_stack_test.go
+++ b/internal/resource_stack_test.go
@@ -479,6 +479,83 @@ func TestStackCreate_KubernetesString_HappyPath(t *testing.T) {
 	}
 }
 
+func TestStackCreate_KubernetesString_IDRecoveredByName(t *testing.T) {
+	mock := NewMockServer(t)
+
+	stacksCalls := 0
+	mock.On("GET", "/stacks", func(w http.ResponseWriter, _ *http.Request) {
+		stacksCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if stacksCalls == 1 {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[{"Id":13,"Name":"terraform-new-secrets","EndpointId":1}]`))
+	})
+
+	// Create body deliberately omits "Id" (mirrors the affected Portainer response).
+	mock.On("POST", "/stacks/create/kubernetes/string", RespondString(
+		http.StatusOK, "application/json", `{"Name":"terraform-new-secrets"}`,
+	))
+	mock.On("PUT", "/stacks/13", RespondJSON(http.StatusOK, map[string]interface{}{"Id": 13}))
+	mock.On("GET", "/stacks/13", RespondJSON(http.StatusOK, map[string]interface{}{
+		"Id": 13, "Name": "terraform-new-secrets", "Status": 1, "Type": 3, "EndpointId": 1, "namespace": "default",
+	}))
+	mock.On("GET", "/stacks/13/file", RespondJSON(http.StatusOK, map[string]interface{}{
+		"StackFileContent": "apiVersion: v1",
+	}))
+
+	r := resourcePortainerStack()
+	d := r.TestResourceData()
+	_ = d.Set("deployment_type", "kubernetes")
+	_ = d.Set("method", "string")
+	_ = d.Set("name", "terraform-new-secrets")
+	_ = d.Set("endpoint_id", 1)
+	_ = d.Set("namespace", "default")
+	_ = d.Set("stack_file_content", "apiVersion: v1")
+
+	if err := rcCreate(r, d, mock.Client()); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if d.Id() != "13" {
+		t.Errorf("expected recovered ID %q, got %q", "13", d.Id())
+	}
+	// The finalize PUT must have targeted the recovered ID, not /stacks/0.
+	if mock.FindRequest("PUT", "/stacks/13") == nil {
+		t.Error("expected finalize PUT to target recovered /stacks/13")
+	}
+	if mock.FindRequest("PUT", "/stacks/0") != nil {
+		t.Error("finalize PUT must not target /stacks/0")
+	}
+}
+
+func TestStackCreate_KubernetesString_IDUnrecoverable(t *testing.T) {
+	mock := NewMockServer(t)
+	mockEmptyStackList(mock) // always empty → recovery lookup also finds nothing
+
+	mock.On("POST", "/stacks/create/kubernetes/string", RespondString(
+		http.StatusOK, "application/json", `{"Name":"ghost"}`,
+	))
+
+	r := resourcePortainerStack()
+	d := r.TestResourceData()
+	_ = d.Set("deployment_type", "kubernetes")
+	_ = d.Set("method", "string")
+	_ = d.Set("name", "ghost")
+	_ = d.Set("endpoint_id", 1)
+	_ = d.Set("namespace", "default")
+	_ = d.Set("stack_file_content", "apiVersion: v1")
+
+	err := rcCreate(r, d, mock.Client())
+	if err == nil {
+		t.Fatal("expected error when created stack ID cannot be resolved, got nil")
+	}
+	if !strings.Contains(err.Error(), "could not be found by name") {
+		t.Errorf("expected a resolve-by-name error, got: %v", err)
+	}
+}
+
 // TestStackCreate_HTTPError ensures a non-200 from the create endpoint
 // propagates as an error and leaves the resource ID empty.
 func TestStackCreate_HTTPError(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements Read and Importer blocks for all 17 Kubernetes resources with stub implementations, enabling brownfield adoption and drift detection.

### Problem

17 of 19 K8s resources had stub Read functions (`return nil`) and zero Importer blocks:
- Users cannot import existing infrastructure via `terraform import`
- No drift detection between state and live cluster
- Infinite plan loops on state loss
- Brownfield adoption is blocked

### Solution

**New file: `resource_kubernetes_common.go`**
- `k8sConfirmExistsByGET()` helper function shared by 13 manifest-based resources
- Issues GET request to confirm object exists
- Detects out-of-band deletion (404 → clears ID)
- **Does NOT refresh the manifest field** — K8s API returns server-expanded objects (status, managedFields, resourceVersion, defaults) that differ from authored YAML. Refreshing would cause permanent diffs and churn workloads on every apply since Update is delete+recreate. Authored manifest stays the source of truth.

**Modified: All 17 K8s resources**
- Added `Importer` block with `ImportStatePassthroughContext`
- Replaced stub Read with real implementations:
  - `namespace`: reads quota, owner, annotations
  - `namespace_system`: reads IsSystem flag
  - `helm`: confirms release exists
  - `ingresses`: confirms existence; spec not refreshed
  - 13 manifest-based: existence check only via helper

### ID Formats

All resources follow one of these patterns:
- Cluster-scoped: `{endpointID}:{name}` (clusterrole, clusterrolebinding, storage)
- Namespaced: `{endpointID}:{namespace}:{name}` (application, configmap, secret, service, etc.)
- Volume: `{endpointID}:{namespace}:{type}:{name}` (persistent-volume-claim, persistent-volume, volume-attachment)
- Helm/Ingress: `{envID}:{namespace}:{name}`

### Testing

End-to-end integration test validates import workflow:
1. Created all 17 resources via `terraform apply` ✅
2. Dropped state (simulated brownfield environment)
3. Imported all 17 resources via `terraform import` ✅
4. First plan showed manifest diffs (expected, null→authored)
5. Applied once to sync manifest into state
6. **Second plan: "No changes" for all 17 resources** ✅

Import now works end-to-end. Users can adopt existing infrastructure without destroy.

### Notes

- No Update or ForceNew changes — those require live API validation (edge_stack lesson: some APIs silently drop payloads with 2xx responses)
- manifest field is intentionally NOT refreshed in Read (see rationale above)
- After `terraform import`, users must set the manifest field in config to match the live object (since Read doesn't populate it)